### PR TITLE
[DE-2173] Unpin requests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         'mock',
     ],
     install_requires=[
-        'requests==2.20.1',
+        'requests~=2.20,>=2.20.1',
         'pytest-runner==4.2',
     ],
     include_package_data=True,


### PR DESCRIPTION
Loosened requests version as libraries should never pin dependency versions. This is blocking upgrade to Airflow 2 as [Airflow works with requests==2.26.0.](https://github.com/apache/airflow/blob/constraints-2-2/constraints-3.7.txt#L461)