### PR TITLE
[DE-2173] Setup for Python 3

### DIFF
--- a/.github/workflows/python-build-and-publish.yml
+++ b/.github/workflows/python-build-and-publish.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 2
+    - name: Set up Python 3
       uses: actions/setup-python@v2
       with:
-        python-version: 2
+        python-version: 3
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip wheel setuptools fabric pycrypto ecdsa pypi-uploader noom_versioning


### PR DESCRIPTION
`pipenv lock` fails in `airflow-base` cause `noom_versioning` package is not available for `grnhse-api` setup. This is not a problem for any other noom package.

[Slack thread](https://noom.slack.com/archives/C01EXHM2ZQW/p1639054038094600)